### PR TITLE
Additions for making embedded-nal feasible

### DIFF
--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -92,7 +92,8 @@ impl<'a> UdpSocket<'a> {
         }
     }
 
-    fn with<R>(&self, f: impl FnOnce(&udp::Socket, &Interface) -> R) -> R {
+    /// Lock the stack, provide access to the underlying smoltcp UDP socket and interface
+    pub fn with<R>(&self, f: impl FnOnce(&udp::Socket, &Interface) -> R) -> R {
         let s = &*self.stack.borrow();
         let socket = s.sockets.get::<udp::Socket>(self.handle);
         f(socket, &s.iface)


### PR DESCRIPTION
* Cherry-pick https://github.com/embassy-rs/embassy/pull/2790
* Make UDP sockets' `.with()` pub

  This should probably not even be part of it (AIU it's one of those locking functions that are only panic free because everyone promises to not call arbitrary code in them that may reenter the lock), but while https://github.com/embassy-rs/embassy/issues/2516 is let mature by having a copy in RIOT-rs's coap branch, we need it pub and promise to be careful 🤞