### PR TITLE
embassy-rp: allow injection of FIFO handler

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -107,6 +107,11 @@ _test = []
 ## program and other details.
 binary-info = ["rt", "dep:rp-binary-info", "rp-binary-info?/binary-info"]
 
+## Inject function for handling FIFO messages.
+## If this feature is enabled, an foreign function 
+## `fn handle_fifo(u32) -> bool` must be implemented.
+fifo-handler = []
+
 [dependencies]
 embassy-sync = { version = "0.6.0"}
 embassy-time-driver = { version = "0.1", optional = true }

--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -84,17 +84,30 @@ impl<const SIZE: usize> Stack<SIZE> {
     }
 }
 
-#[cfg(all(feature = "rt", feature = "rp2040"))]
-#[interrupt]
+#[cfg(feature = "fifo-handler")]
+extern "Rust" {
+    fn handle_fifo_token(token: u32) -> bool;
+}
+
+#[cfg(feature = "rt")]
 #[link_section = ".data.ram_func"]
-unsafe fn SIO_IRQ_PROC1() {
+#[inline]
+unsafe fn sio_handler() {
     let sio = pac::SIO;
     // Clear IRQ
     sio.fifo().st().write(|w| w.set_wof(false));
 
     while sio.fifo().st().read().vld() {
+        let token = fifo_read_wfe();
+
+        // Forward to user handler.
+        #[cfg(feature = "fifo-handler")]
+        if handle_fifo_token(token) {
+            continue;
+        }
+
         // Pause CORE1 execution and disable interrupts
-        if fifo_read_wfe() == PAUSE_TOKEN {
+        if token == PAUSE_TOKEN {
             cortex_m::interrupt::disable();
             // Signal to CORE0 that execution is paused
             fifo_write(PAUSE_TOKEN);
@@ -109,29 +122,25 @@ unsafe fn SIO_IRQ_PROC1() {
     }
 }
 
+#[cfg(all(feature = "rt", feature = "rp2040"))]
+#[interrupt]
+#[link_section = ".data.ram_func"]
+unsafe fn SIO_IRQ_PROC0() {
+    sio_handler();
+}
+
+#[cfg(all(feature = "rt", feature = "rp2040"))]
+#[interrupt]
+#[link_section = ".data.ram_func"]
+unsafe fn SIO_IRQ_PROC1() {
+    sio_handler();
+}
+
 #[cfg(all(feature = "rt", feature = "_rp235x"))]
 #[interrupt]
 #[link_section = ".data.ram_func"]
 unsafe fn SIO_IRQ_FIFO() {
-    let sio = pac::SIO;
-    // Clear IRQ
-    sio.fifo().st().write(|w| w.set_wof(false));
-
-    while sio.fifo().st().read().vld() {
-        // Pause CORE1 execution and disable interrupts
-        if fifo_read_wfe() == PAUSE_TOKEN {
-            cortex_m::interrupt::disable();
-            // Signal to CORE0 that execution is paused
-            fifo_write(PAUSE_TOKEN);
-            // Wait for `resume` signal from CORE0
-            while fifo_read_wfe() != RESUME_TOKEN {
-                cortex_m::asm::nop();
-            }
-            cortex_m::interrupt::enable();
-            // Signal to CORE0 that execution is resumed
-            fifo_write(RESUME_TOKEN);
-        }
-    }
+    sio_handler();
 }
 
 /// Spawn a function on this core
@@ -255,23 +264,51 @@ where
 
     // Wait until the other core has copied `entry` before returning.
     fifo_read();
+
+    // Enable FIFO interrupts from core1.
+    #[cfg(feature = "rp2040")]
+    unsafe {
+        interrupt::SIO_IRQ_PROC0.enable()
+    };
+    #[cfg(feature = "_rp235x")]
+    unsafe {
+        interrupt::SIO_IRQ_FIFO.enable()
+    };
 }
 
 /// Pause execution on CORE1.
 pub fn pause_core1() {
     if IS_CORE1_INIT.load(Ordering::Acquire) {
-        fifo_write(PAUSE_TOKEN);
-        // Wait for CORE1 to signal it has paused execution.
-        while fifo_read() != PAUSE_TOKEN {}
+        cortex_m::interrupt::free(|_| {
+            fifo_write(PAUSE_TOKEN);
+            // Wait for CORE1 to signal it has paused execution.
+            loop {
+                let token = fifo_read();
+                if token == PAUSE_TOKEN {
+                    break;
+                }
+                #[cfg(feature = "fifo-handler")]
+                handle_fifo_token(token);
+            }
+        })
     }
 }
 
 /// Resume CORE1 execution.
 pub fn resume_core1() {
     if IS_CORE1_INIT.load(Ordering::Acquire) {
-        fifo_write(RESUME_TOKEN);
-        // Wait for CORE1 to signal it has resumed execution.
-        while fifo_read() != RESUME_TOKEN {}
+        cortex_m::interrupt::free(|_| {
+            fifo_write(RESUME_TOKEN);
+            // Wait for CORE1 to signal it has resumed execution.
+            loop {
+                let token = fifo_read();
+                if token == RESUME_TOKEN {
+                    break;
+                }
+                #[cfg(feature = "fifo-handler")]
+                handle_fifo_token(token);
+            }
+        })
     }
 }
 


### PR DESCRIPTION
- Add `fifo-handler` feature for injecting a custom handler for FIFO messages: `fn handle_fifo(token: u32) -> bool`
- Also enable FIFO queue in core1->core0 direction.
- disable interrupts while waiting for the response in `{pause,resume}_core1`, to prevent that the now enabled `SIO_IRQ_PROC0` interrupt preempts it

Note: I used your most recent branch as target for this PR. Maybe create a new branch instead?